### PR TITLE
Point to staging spreadsheet when running test in dev environment

### DIFF
--- a/tests/fixtures/dataset_fixture.py
+++ b/tests/fixtures/dataset_fixture.py
@@ -31,7 +31,7 @@ class DatasetFixture:
         branch = self.deployment
 
         if self.deployment == 'dev':
-            branch = 'develop'
+            branch = 'staging'
 
         if self.deployment == 'prod':
             branch = 'master'


### PR DESCRIPTION
ebi-ait/dcp-ingest-central#434

The test couldn't download the test spreadsheet from the metadata-schema repo’s develop branch anymore. Pointing the test to use metadata-schema's staging spreadsheet when the test is running in ingest dev environment.