### PR TITLE
dcp-447/Add initial test for direct archiving

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,7 @@ stages:
 test_ingest_to_upload:
   stage: test
   script:
-     - python -m unittest tests.test_ingest.TestRun.test_ss2_ingest_to_upload
+     - python -m unittest tests.test_ingest.TestRun.test_ingest_to_upload
   only:
     - dev
     - staging

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -57,6 +57,15 @@ test_bulk_update:
   tags:
     - ingest-integration-tests
 
+test_direct_archiving:
+  stage: test
+  script:
+     - python -m unittest tests.test_ingest.TestRun.test_direct_archiving
+  only:
+    - dev
+    - staging
+  tags:
+    - ingest-integration-tests
 
 before_script:
   - apt-get -y update

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ export HCA_UTIL_ADMIN_ACCESS=$(aws secretsmanager get-secret-value --region us-e
 export HCA_UTIL_ADMIN_SECRET=$(aws secretsmanager get-secret-value --region us-east-1 --secret-id hca/util/aws-access-keys --query SecretString --output text | jq -jr '.ADMIN_SECRET_ACCESS_KEY'); \
 export HCA_UTIL_ADMIN_PROFILE='test-hca-util-admin'; \
 export GOOGLE_APPLICATION_CREDENTIALS=_local/gcp-credentials-dev.json; \
-python3 -m unittest tests.test_ingest.TestRun.test_ss2_ingest_to_upload
+python3 -m unittest tests.test_ingest.TestRun.test_ingest_to_upload
 ``` 
 
 #### Gitlab Runner

--- a/tests/ingest_agents.py
+++ b/tests/ingest_agents.py
@@ -242,14 +242,9 @@ class IngestArchiverAgent:
             'Api-Key': self.api_key
         }
 
-    def archive_submission(self, ingest_submission_uuid: str):
-        data = {
-            'submission_uuid': ingest_submission_uuid,
-            'alias_prefix': 'INGEST_INTEGRATION_TEST',
-            'exclude_types': 'sequencingRun'
-        }
+    def archive_submission(self, payload: dict):
         archive_submission_url = f'{self.ingest_archiver_url}/archiveSubmissions'
-        r = requests.post(archive_submission_url, json=data, headers=self.headers)
+        r = requests.post(archive_submission_url, json=payload, headers=self.headers)
         r.raise_for_status()
 
     def get_dsp_submission_uuid(self, ingest_submission_uuid):

--- a/tests/runners/dataset_runner.py
+++ b/tests/runners/dataset_runner.py
@@ -9,6 +9,8 @@ from tests.runners.submission_manager import SubmissionManager
 from tests.utils import Progress
 from tests.wait_for import WaitFor
 
+RELEASE_DATE_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
+
 BIOSAMPLES_PREFIX = 'SAME'
 
 
@@ -81,7 +83,7 @@ class DatasetRunner:
             project = projects[0]
             project_url = project.get_url()
             now = datetime.now()
-            r = self.ingest_client_api.patch(project_url, {'releaseDate': now.strftime('%Y-%m-%dT%H:%M:%SZ')})
+            r = self.ingest_client_api.patch(project_url, {'releaseDate': now.strftime(RELEASE_DATE_FORMAT)})
             r.raise_for_status()
 
     def __create_archive_submission_payload(self, is_direct: bool):

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -56,6 +56,12 @@ class TestIngest(unittest.TestCase):
         self.runner.archived_run(dataset_fixture)
         return self.runner
 
+    def ingest_to_direct_archives(self, dataset_name: str):
+        dataset_fixture = DatasetFixture(dataset_name, self.deployment)
+        self.runner = DatasetRunner(self.ingest_broker, self.ingest_api, self.ingest_archiver, self.ingest_client_api)
+        self.runner.direct_archived_run(dataset_fixture)
+        return self.runner
+
     def ingest_to_terra(self, dataset_name):
         dataset_fixture = DatasetFixture(dataset_name, self.deployment)
         self.runner = DatasetRunner(self.ingest_broker, self.ingest_api)
@@ -81,18 +87,21 @@ class TestIngest(unittest.TestCase):
 class TestRun(TestIngest):
 
     def test_ss2_ingest_to_upload(self):
-        runner = self.ingest_and_upload_only('SS2')
+        self.ingest_and_upload_only('SS2')
 
     def test_big_submission_run(self):
         self.ingest_big_submission()
 
     # cannot be run in prod, need to know how to delete the submitted data to archives
     def test_ingest_to_archives(self):
-        runner = self.ingest_to_archives('SS2')
+        self.ingest_to_archives('SS2')
+
+    def test_direct_archiving(self):
+        self.ingest_to_direct_archives('SS2')
 
     # cannot be run in prod, need to know how to delete the submitted data to terra
     def test_ingest_to_terra(self):
-        runner = self.ingest_to_terra('SS2')
+        self.ingest_to_terra('SS2')
 
     def test_bulk_update(self):
         self.bulk_update('SS2')

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -14,8 +14,6 @@ from tests.runners.bulk_update_manager import BulkUpdateManager
 from tests.runners.bulk_update_runner import BulkUpdateRunner
 from tests.runners.dataset_runner import DatasetRunner
 
-SS2_DATASET_NAME = 'SS2'
-
 DEPLOYMENTS = ('dev', 'integration', 'staging', 'prod')
 
 
@@ -88,25 +86,27 @@ class TestIngest(unittest.TestCase):
 
 class TestRun(TestIngest):
 
-    def test_ss2_ingest_to_upload(self):
-        self.ingest_and_upload_only(SS2_DATASET_NAME)
+    DATASET_NAME = 'SS2'
+
+    def test_ingest_to_upload(self):
+        self.ingest_and_upload_only(TestRun.DATASET_NAME)
 
     def test_big_submission_run(self):
         self.ingest_big_submission()
 
     # cannot be run in prod, need to know how to delete the submitted data to archives
     def test_ingest_to_archives(self):
-        self.ingest_to_archives(SS2_DATASET_NAME)
+        self.ingest_to_archives(TestRun.DATASET_NAME)
 
     def test_direct_archiving(self):
-        self.ingest_to_direct_archives(SS2_DATASET_NAME)
+        self.ingest_to_direct_archives(TestRun.DATASET_NAME)
 
     # cannot be run in prod, need to know how to delete the submitted data to terra
     def test_ingest_to_terra(self):
-        self.ingest_to_terra(SS2_DATASET_NAME)
+        self.ingest_to_terra(TestRun.DATASET_NAME)
 
     def test_bulk_update(self):
-        self.bulk_update(SS2_DATASET_NAME)
+        self.bulk_update(TestRun.DATASET_NAME)
 
 
 if __name__ == '__main__':

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -14,6 +14,8 @@ from tests.runners.bulk_update_manager import BulkUpdateManager
 from tests.runners.bulk_update_runner import BulkUpdateRunner
 from tests.runners.dataset_runner import DatasetRunner
 
+SS2_DATASET_NAME = 'SS2'
+
 DEPLOYMENTS = ('dev', 'integration', 'staging', 'prod')
 
 
@@ -87,24 +89,24 @@ class TestIngest(unittest.TestCase):
 class TestRun(TestIngest):
 
     def test_ss2_ingest_to_upload(self):
-        self.ingest_and_upload_only('SS2')
+        self.ingest_and_upload_only(SS2_DATASET_NAME)
 
     def test_big_submission_run(self):
         self.ingest_big_submission()
 
     # cannot be run in prod, need to know how to delete the submitted data to archives
     def test_ingest_to_archives(self):
-        self.ingest_to_archives('SS2')
+        self.ingest_to_archives(SS2_DATASET_NAME)
 
     def test_direct_archiving(self):
-        self.ingest_to_direct_archives('SS2')
+        self.ingest_to_direct_archives(SS2_DATASET_NAME)
 
     # cannot be run in prod, need to know how to delete the submitted data to terra
     def test_ingest_to_terra(self):
-        self.ingest_to_terra('SS2')
+        self.ingest_to_terra(SS2_DATASET_NAME)
 
     def test_bulk_update(self):
-        self.bulk_update('SS2')
+        self.bulk_update(SS2_DATASET_NAME)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
dcp-447

Changes:
- Add new test for direct archiving. This test only covering for direct archiving biomaterials to the BioSamples archive. This is the initial version of this test. Later on this test should cover direct archiving project and other entities to BioStudies and ENA archives. 

I tested this on the dev environments with wwwdev BioSamples env and it worked fined. The biomaterials got accessioned by BioSamples.