### PR TITLE
Create a docker image to make integration tests faster

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,9 +1,30 @@
-image: python:3.6
+variables:
+  IMAGE_NAME: "quay.io/ebi-ait/ingest-base-images:ingest-integration-tests"
 
 stages:
+  - build
   - test
 
+build:
+  stage: build
+  only:
+    refs:
+      - dev
+    changes:
+      - Dockerfile
+      - requirements.txt
+      - src/**/*
+  tags:
+    - dind
+  before_script:
+    - echo "Building image..."
+  script:
+    - echo $QUAY_PASSWORD | docker login quay.io -u $QUAY_USERNAME --password-stdin
+    - docker build -t $IMAGE_NAME .
+    - docker push $IMAGE_NAME
+    
 test_ingest_to_upload:
+  image: $IMAGE_NAME
   stage: test
   script:
      - python -m unittest tests.test_ingest.TestRun.test_ingest_to_upload
@@ -15,6 +36,7 @@ test_ingest_to_upload:
 
 
 test_ingest_to_archives:
+  image: $IMAGE_NAME
   stage: test
   script:
      - python -m unittest tests.test_ingest.TestRun.test_ingest_to_archives
@@ -26,6 +48,7 @@ test_ingest_to_archives:
 
 
 test_ingest_to_terra:
+  image: $IMAGE_NAME
   stage: test
   script:
      - python -m unittest tests.test_ingest.TestRun.test_ingest_to_terra
@@ -37,6 +60,7 @@ test_ingest_to_terra:
 
 
 test_big_submission:
+  image: $IMAGE_NAME
   stage: test
   script:
      - python -m unittest tests.test_ingest.TestRun.test_big_submission_run
@@ -47,6 +71,7 @@ test_big_submission:
     - ingest-integration-tests
 
 test_bulk_update:
+  image: $IMAGE_NAME
   stage: test
   script:
      - python -m unittest tests.test_ingest.TestRun.test_bulk_update
@@ -58,6 +83,7 @@ test_bulk_update:
     - ingest-integration-tests
 
 test_direct_archiving:
+  image: $IMAGE_NAME
   stage: test
   script:
      - python -m unittest tests.test_ingest.TestRun.test_direct_archiving
@@ -68,10 +94,6 @@ test_direct_archiving:
     - ingest-integration-tests
 
 before_script:
-  - apt-get -y update
-  - apt-get -y install jq
-  - apt-get -y install awscli
-  - pip install -r requirements.txt
   - export INGEST_API_JWT_AUDIENCE=https://dev.data.humancellatlas.org/
   - export DEPLOYMENT_ENV=$CI_COMMIT_REF_NAME
   - export DEPLOYMENT_STAGE=${DEPLOYMENT_ENV}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,24 @@ stages:
   - build
   - test
 
+default:
+  before_script:
+    - export INGEST_API_JWT_AUDIENCE=https://dev.data.humancellatlas.org/
+    - export DEPLOYMENT_ENV=$CI_COMMIT_REF_NAME
+    - export DEPLOYMENT_STAGE=${DEPLOYMENT_ENV}
+    - export ARCHIVER_API_KEY=$(aws secretsmanager get-secret-value --region us-east-1 --secret-id ingest/${DEPLOYMENT_ENV}/secrets --query SecretString --output text | jq -jr '.archiver_api_key')
+    - export HCA_UTIL_ADMIN_ACCESS=$(aws secretsmanager get-secret-value --region us-east-1 --secret-id hca/util/aws-access-keys --query SecretString --output text | jq -jr '.ADMIN_ACCESS_KEY')
+    - export HCA_UTIL_ADMIN_SECRET=$(aws secretsmanager get-secret-value --region us-east-1 --secret-id hca/util/aws-access-keys --query SecretString --output text | jq -jr '.ADMIN_SECRET_ACCESS_KEY')
+    - export HCA_UTIL_ADMIN_PROFILE='test-hca-util-admin'
+    - aws secretsmanager get-secret-value --region us-east-1 --secret-id ingest/${DEPLOYMENT_ENV}/gcp-credentials.json | jq -r .SecretString > gcp-credentials.json
+    - export GOOGLE_APPLICATION_CREDENTIALS=$(pwd -P)/gcp-credentials.json
+  image: $IMAGE_NAME
+  tags:
+    - ingest-integration-tests
+
 build:
+  inherit:
+    default: false
   stage: build
   only:
     refs:
@@ -16,62 +33,47 @@ build:
       - src/**/*
   tags:
     - dind
-  before_script:
-    - echo "Building image..."
   script:
     - echo $QUAY_PASSWORD | docker login quay.io -u $QUAY_USERNAME --password-stdin
     - docker build -t $IMAGE_NAME .
     - docker push $IMAGE_NAME
     
 test_ingest_to_upload:
-  image: $IMAGE_NAME
   stage: test
   script:
      - python -m unittest tests.test_ingest.TestRun.test_ingest_to_upload
   only:
     - dev
     - staging
-  tags:
-    - ingest-integration-tests
 
 
 test_ingest_to_archives:
-  image: $IMAGE_NAME
   stage: test
   script:
      - python -m unittest tests.test_ingest.TestRun.test_ingest_to_archives
   only:
     - dev
     - staging
-  tags:
-    - ingest-integration-tests
 
 
 test_ingest_to_terra:
-  image: $IMAGE_NAME
   stage: test
   script:
      - python -m unittest tests.test_ingest.TestRun.test_ingest_to_terra
   only:
     - dev
     - staging
-  tags:
-    - ingest-integration-tests
 
 
 test_big_submission:
-  image: $IMAGE_NAME
   stage: test
   script:
      - python -m unittest tests.test_ingest.TestRun.test_big_submission_run
   only:
     - dev
     - staging
-  tags:
-    - ingest-integration-tests
 
 test_bulk_update:
-  image: $IMAGE_NAME
   stage: test
   script:
      - python -m unittest tests.test_ingest.TestRun.test_bulk_update
@@ -79,27 +81,11 @@ test_bulk_update:
     - dev
     - staging
     - prod
-  tags:
-    - ingest-integration-tests
 
 test_direct_archiving:
-  image: $IMAGE_NAME
   stage: test
   script:
      - python -m unittest tests.test_ingest.TestRun.test_direct_archiving
   only:
     - dev
     - staging
-  tags:
-    - ingest-integration-tests
-
-before_script:
-  - export INGEST_API_JWT_AUDIENCE=https://dev.data.humancellatlas.org/
-  - export DEPLOYMENT_ENV=$CI_COMMIT_REF_NAME
-  - export DEPLOYMENT_STAGE=${DEPLOYMENT_ENV}
-  - export ARCHIVER_API_KEY=$(aws secretsmanager get-secret-value --region us-east-1 --secret-id ingest/${DEPLOYMENT_ENV}/secrets --query SecretString --output text | jq -jr '.archiver_api_key')
-  - export HCA_UTIL_ADMIN_ACCESS=$(aws secretsmanager get-secret-value --region us-east-1 --secret-id hca/util/aws-access-keys --query SecretString --output text | jq -jr '.ADMIN_ACCESS_KEY')
-  - export HCA_UTIL_ADMIN_SECRET=$(aws secretsmanager get-secret-value --region us-east-1 --secret-id hca/util/aws-access-keys --query SecretString --output text | jq -jr '.ADMIN_SECRET_ACCESS_KEY')
-  - export HCA_UTIL_ADMIN_PROFILE='test-hca-util-admin'
-  - aws secretsmanager get-secret-value --region us-east-1 --secret-id ingest/${DEPLOYMENT_ENV}/gcp-credentials.json | jq -r .SecretString > gcp-credentials.json
-  - export GOOGLE_APPLICATION_CREDENTIALS=$(pwd -P)/gcp-credentials.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,5 +14,3 @@ RUN pip install --upgrade pip
 RUN pip install -r requirements.txt
 
 ADD ./tests ./tests
-
-RUN aws --version

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,9 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
 
 ADD ./requirements.txt ./
+RUN pip install --upgrade pip
+RUN pip install -r requirements.txt
+
 ADD ./tests ./tests
 
 RUN aws --version
-RUN pip install --upgrade pip
-RUN pip install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2
 
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
 
-ADD ./requirements.txt ./
 RUN pip install --upgrade pip
+ADD ./requirements.txt ./
 RUN pip install -r requirements.txt
 
 ADD ./tests ./tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2
     unzip awscliv2.zip && \
     ./aws/install
 
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
 
 ADD ./requirements.txt ./
 ADD ./tests ./tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:latest
+
+RUN apt-get update
+RUN apt-get install -y python3-dev python3 python3-pip curl unzip git
+
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \ 
+    unzip awscliv2.zip && \
+    ./aws/install
+
+
+ADD ./requirements.txt ./
+ADD ./tests ./tests
+
+RUN aws --version
+RUN pip install --upgrade pip
+RUN pip install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:latest
 
 RUN apt-get update
-RUN apt-get install -y python3-dev python3 python3-pip curl unzip git
+RUN apt-get install -y python3-dev python3 python3-pip curl unzip git jq
 
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \ 
     unzip awscliv2.zip && \


### PR DESCRIPTION
dcp-571

- Creates a docker image with all dependencies installed so we can run the tests faster
-  Creates a build stage that runs on push to `dev` to build the image and push it to quay
  -  **IMPORTANT** This relies on the fact that we will always push our changes to `dev` first before merging them into `staging` and `prod`
- tidies some of the defaults up a bit
- Relates to [this PR](https://github.com/ebi-ait/gitlab-ci-templates/pull/2)