### PR TITLE
Don't use commit hash for image name

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 variables:
-  INTEGRATION_TEST_IMAGE_NAME: quay.io/ebi-ait/ingest-integration-tests:${CI_COMMIT_REF_NAME}_${CI_COMMIT_SHORT_SHA}
+  INTEGRATION_TEST_IMAGE_NAME: quay.io/ebi-ait/ingest-integration-tests:${CI_COMMIT_REF_NAME}
 stages:
   - build
   - test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,7 +34,7 @@ build:
     DOCKER_CERT_PATH: "$DOCKER_TLS_CERTDIR/client"
   stage: build
   rules:
-    - if: '$CI_PIPELINE_SOURCE == "push"'
+    - if: '$CI_PIPELINE_SOURCE == "push" && ($CI_COMMIT_BRANCH == "dev" || $CI_COMMIT_BRANCH == "staging" || $CI_COMMIT_BRANCH == "prod")'
       changes:
         - Dockerfile
         - requirements.txt


### PR DESCRIPTION
I think this is the way to go for building images. This is assuming we never want to run integration tests with an **old** version of integration tests. I don't see a good reason why we would. With this PR, if you trigger an old pipeline, it will always use the image of whatever branch you're triggering for (`dev`, `staging`, or `prod`) and there is no commit specific images.

Reasons for this:

1. Previous setup wouldn't work if you don't change one of the files specified in `changes`.
  - The commit hash will update but an image won't be built. The next pipeline run will try to pull an image with a commit hash that doesn't exist.
2. We don't need to store all of the old images of the integration tests. We have git, I think that's enough VC.
3. We could solve (1) by just doing builds for any change but that's unnecessary - changing some files doesn't the  output of integration tests